### PR TITLE
Add CLA Assistant Lite workflow

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,48 @@
+name: "CLA Assistant"
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  actions: write
+  contents: read          # signatures live in the private verivus-oss/cla-signatures repo
+  pull-requests: write
+  statuses: write
+
+jobs:
+  CLAAssistant:
+    runs-on: ubuntu-latest
+    # Only do work on the sign/recheck comment or a pull_request_target event.
+    if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+    steps:
+      # Mint a short-lived (1h) installation token scoped to ONLY the private
+      # signature ledger. No PAT is stored anywhere; the app private key lives
+      # in the org secret CLA_APP_KEY and the app id in the org var CLA_APP_ID.
+      - name: "Mint signature-ledger token"
+        id: cla-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.CLA_APP_ID }}
+          private-key: ${{ secrets.CLA_APP_KEY }}
+          owner: verivus-oss
+          repositories: cla-signatures
+
+      - name: "CLA Assistant"
+        # contributor-assistant/github-action is archived/read-only upstream, so we
+        # pin to the audited v2.6.1 commit SHA rather than a mutable tag.
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Short-lived app token (not a PAT) used only to write to cla-signatures.
+          PERSONAL_ACCESS_TOKEN: ${{ steps.cla-token.outputs.token }}
+        with:
+          path-to-document: 'https://github.com/verivus-oss/cla/blob/main/CLA.md'
+          path-to-signatures: 'signatures/version1/cla.json'
+          remote-organization-name: 'verivus-oss'
+          remote-repository-name: 'cla-signatures'
+          branch: 'signatures'
+          allowlist: 'verivus-open,verivusOSS-releases,wernerkasselman-au,dependabot[bot],bot*'
+          lock-pullrequest-aftermerge: true


### PR DESCRIPTION
Adds `.github/workflows/cla.yml` so this repo participates in the org-wide
Contributor License Agreement (CLA) check.

How it works:
- On each pull request, the CLA Assistant Lite action verifies that every
  commit author has signed the CLA at
  https://github.com/verivus-oss/cla/blob/main/CLA.md
- An unsigned contributor signs by posting this comment on their PR:
  "I have read the CLA Document and I hereby sign the CLA"
- Signatures are stored in the private `verivus-oss/cla-signatures` repo and are
  valid across every `verivus-oss` repo (sign once).

Security notes:
- Both actions are pinned to commit SHAs (the CLA action upstream is archived).
- No PAT is used. A dedicated org GitHub App mints a short-lived, repo-scoped
  token at runtime to write signatures.

PREREQUISITE before merging: the "Verivus CLA Assistant" GitHub App plus the
org-level `CLA_APP_ID` variable and `CLA_APP_KEY` secret must be configured.
Until then the token step will fail, so please do not merge this yet.